### PR TITLE
Upgrade miniconda checkout to v3

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,14 +14,13 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           channels: conda-forge,defaults
-          mamba-version: "*"
+          use-mamba: true
           environment-file: environment.yml
-          cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
-          cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
+          activate-environment: test
       - name: install additional dependencies
         run: |
           echo "installing additional dependencies from environment_development.yml"
@@ -57,14 +56,13 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           channels: conda-forge,defaults
-          mamba-version: "*"
+          use-mamba: true
           environment-file: environment.yml
-          cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
-          cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
+          activate-environment: test
       - name: build pypi pacakge
         run: |
           echo "versioningit $(versioningit .)"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -15,14 +15,13 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           channels: conda-forge,defaults
-          mamba-version: "*"
+          use-mamba: true
           environment-file: environment.yml
-          cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
-          cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
+          activate-environment: test
       - name: install additional dependencies
         run: |
           echo "installing additional dependencies if cannot be installed from conda"
@@ -52,15 +51,14 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: "latest"
           auto-update-conda: true
           channels: conda-forge,defaults
-          mamba-version: "*"
+          use-mamba: true
           environment-file: environment.yml
-          cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
-          cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
+          activate-environment: test
       - name: install additional dependencies
         run: |
           echo "installing additional dependencies if cannot be installed from conda"


### PR DESCRIPTION
This PR introduces the following changes:

- upgrade miniconda checkout to v3
- fix outdated syntax issue


> EWM item: [7548](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7548)