### PR TITLE
Add automated Homebrew tap update on release

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -186,7 +186,20 @@ jobs:
         run: |
           DMG_URL="https://github.com/ornlneutronimaging/bm3dornl/releases/download/v${{ steps.version.outputs.version }}/bm3dornl-${{ steps.version.outputs.version }}-macos-arm64.dmg"
           echo "Downloading $DMG_URL"
-          curl -sL "$DMG_URL" -o bm3dornl.dmg
+          curl -fSL --retry 3 --retry-delay 5 "$DMG_URL" -o bm3dornl.dmg
+
+          # Verify the downloaded file is a valid DMG (not an error page)
+          if [ ! -s bm3dornl.dmg ]; then
+            echo "Error: Downloaded file is empty"
+            exit 1
+          fi
+
+          # Check for DMG magic bytes (first 4 bytes should not be HTML)
+          if head -c 15 bm3dornl.dmg | grep -q '<!DOCTYPE\|<html'; then
+            echo "Error: Downloaded file appears to be HTML, not a DMG"
+            exit 1
+          fi
+
           SHA256=$(sha256sum bm3dornl.dmg | cut -d' ' -f1)
           echo "sha256=$SHA256" >> $GITHUB_OUTPUT
           echo "SHA256: $SHA256"
@@ -215,6 +228,12 @@ jobs:
         run: |
           cd homebrew-bm3dornl
           git add Casks/bm3dornl.rb
-          git commit -m "Update bm3dornl to ${{ steps.version.outputs.version }}"
-          git push origin main
-          echo "Successfully updated Homebrew tap to version ${{ steps.version.outputs.version }}"
+
+          # Only commit and push if there are actual changes
+          if git diff --staged --quiet; then
+            echo "No changes to commit - tap is already up to date for version ${{ steps.version.outputs.version }}"
+          else
+            git commit -m "Update bm3dornl to ${{ steps.version.outputs.version }}"
+            git push origin main
+            echo "Successfully updated Homebrew tap to version ${{ steps.version.outputs.version }}"
+          fi


### PR DESCRIPTION
## Summary

- Adds `update-homebrew` job to `gui.yml` workflow
- Automatically updates the [homebrew-bm3dornl](https://github.com/ornlneutronimaging/homebrew-bm3dornl) tap when a stable release is published
- Skips pre-release versions (rc, alpha, beta)

## What the job does

1. Extracts version from tag
2. Waits for DMG asset to be available on GitHub Release
3. Downloads DMG and calculates SHA256
4. Clones homebrew-bm3dornl repo
5. Updates `version` and `sha256` in `Casks/bm3dornl.rb`
6. Commits and pushes changes

## Setup required

Add a repository secret `HOMEBREW_TAP_TOKEN` with a PAT that has `repo` scope.

## Test plan

- [x] Add `HOMEBREW_TAP_TOKEN` secret to repository
- [x] Merge this PR
- [ ] Create a test release (e.g., v0.7.1) and verify the tap is updated automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)