### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bm3dornl"
-version = "0.7.0"
+version = "0.7.1"
 description = "BM3D for streak artifact removal in neutron imaging"
 requires-python = ">=3.12"
 dependencies = [
@@ -20,7 +20,7 @@ documentation = "https://bm3dornl.readthedocs.io/en/latest/"
 issues = "https://github.com/ornlneutronimaging/bm3dornl/issues"
 
 [project.optional-dependencies]
-gui = ["bm3dornl-gui==0.7.0"]
+gui = ["bm3dornl-gui==0.7.1"]
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]

--- a/src/rust_core/Cargo.toml
+++ b/src/rust_core/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/bm3d_core", "crates/bm3d_python", "crates/bm3d_gui_egui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 
 [workspace.dependencies]

--- a/src/rust_core/crates/bm3d_gui_egui/pyproject.toml
+++ b/src/rust_core/crates/bm3d_gui_egui/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bm3dornl-gui"
-version = "0.7.0"
+version = "0.7.1"
 description = "GUI application for BM3D ring artifact removal in neutron imaging"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bumps version from 0.7.0 to 0.7.1 to test the automated Homebrew tap update pipeline.

## Files changed

- `pyproject.toml`
- `src/rust_core/Cargo.toml`
- `src/rust_core/crates/bm3d_gui_egui/pyproject.toml`

## After merge

Tag the release:
```bash
git fetch origin
git tag v0.7.1 origin/next
git push origin v0.7.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)