### PR TITLE
fix: use circular frequency distance in PSD construction

### DIFF
--- a/scripts/reconstruct_and_compare.py
+++ b/scripts/reconstruct_and_compare.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Process sinograms with streak mode BM3D, reconstruct via FBP, and save images.
+
+Produces side-by-side comparison of:
+  - Raw (no ring removal) FBP reconstruction
+  - SVD ring removal FBP reconstruction (reference)
+  - Streak mode ring removal FBP reconstruction (our fix)
+
+Output images are saved to output_recon/ for visual inspection.
+
+Usage:
+    pixi run python scripts/reconstruct_and_compare.py
+    pixi run python scripts/reconstruct_and_compare.py --slice 0140
+    pixi run python scripts/reconstruct_and_compare.py --center 2116.5 --angles 360
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+from scipy.signal import correlate
+from skimage.transform import iradon
+
+from bm3dornl.bm3d import bm3d_ring_artifact_removal
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "sinogram_extract"
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "output_recon"
+
+
+def load_tiff(path: Path) -> np.ndarray:
+    return np.array(Image.open(path)).astype(np.float32)
+
+
+def find_rotation_center(sinogram: np.ndarray, angle_range: float = 180.0) -> float:
+    """Find center of rotation by cross-correlating proj_0 with flipped proj_180.
+
+    Uses the central 50% of the detector to avoid edge effects.
+    For a 360-deg scan, the projection at 180 degrees is at index n_proj//2.
+    For a 180-deg scan, we use the first and last projections.
+    """
+    n_proj, n_cols = sinogram.shape
+
+    if angle_range >= 360.0:
+        idx_180 = n_proj // 2
+        proj_0 = sinogram[0, :]
+        proj_180 = sinogram[idx_180, ::-1]
+    else:
+        proj_0 = sinogram[0, :]
+        proj_180 = sinogram[-1, ::-1]
+
+    # Use central strip to avoid edge artifacts
+    margin = n_cols // 4
+    strip = slice(margin, n_cols - margin)
+    corr = correlate(proj_0[strip], proj_180[strip], mode="full")
+    shift = np.argmax(corr) - (len(proj_180[strip]) - 1)
+    center = (n_cols + shift) / 2.0
+    return center
+
+
+def shift_sinogram_to_center(sinogram: np.ndarray, center: float) -> np.ndarray:
+    """Shift sinogram columns so rotation center aligns with detector midpoint.
+
+    Uses Fourier-based sub-pixel shift for accuracy.
+    """
+    n_cols = sinogram.shape[1]
+    midpoint = n_cols / 2.0
+    pixel_shift = midpoint - center
+
+    if abs(pixel_shift) < 0.1:
+        return sinogram
+
+    from scipy.ndimage import shift as ndi_shift
+
+    shifted = ndi_shift(sinogram, [0, pixel_shift], mode="nearest")
+    return shifted
+
+
+def reconstruct_fbp(sinogram: np.ndarray, angle_range: float = 360.0) -> np.ndarray:
+    """FBP reconstruction from sinogram.
+
+    sinogram shape: (n_projections, n_detector_columns)
+    iradon expects: (n_detector_columns, n_projections)
+    """
+    n_proj = sinogram.shape[0]
+    theta = np.linspace(0, angle_range, n_proj, endpoint=False)
+    recon = iradon(sinogram.T, theta=theta, filter_name="ramp", circle=True)
+    return recon
+
+
+def to_uint8(img: np.ndarray, vmin: float, vmax: float) -> np.ndarray:
+    if vmax <= vmin:
+        return np.zeros_like(img, dtype=np.uint8)
+    clipped = np.clip(img, vmin, vmax)
+    return ((clipped - vmin) / (vmax - vmin) * 255).astype(np.uint8)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Reconstruct sinograms and compare ring removal methods")
+    parser.add_argument("--slice", type=str, default=None, help="Process only this slice ID (e.g. 0140)")
+    parser.add_argument("--center", type=float, default=None, help="Rotation center (pixel). Auto-detected if omitted.")
+    parser.add_argument("--angles", type=float, default=180.0, help="Angular range in degrees (default: 180)")
+    args = parser.parse_args()
+
+    if not DATA_DIR.exists():
+        print(f"Data directory not found: {DATA_DIR}")
+        sys.exit(1)
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+
+    if args.slice:
+        pre_files = sorted(DATA_DIR.glob(f"sino_pre_ring_slice{args.slice}.tiff"))
+    else:
+        pre_files = sorted(DATA_DIR.glob("sino_pre_ring_slice*.tiff"))
+
+    if not pre_files:
+        print("No matching sinograms found.")
+        sys.exit(1)
+
+    for pre_path in pre_files:
+        slice_id = pre_path.stem.replace("sino_pre_ring_slice", "")
+        svd_path = DATA_DIR / f"sino_post_ring_svd_slice{slice_id}.tiff"
+
+        print(f"\n=== Slice {slice_id} ===")
+        sinogram = load_tiff(pre_path)
+        print(f"  Sinogram shape: {sinogram.shape}")
+
+        # Find or use provided rotation center
+        if args.center is not None:
+            center = args.center
+        else:
+            center = find_rotation_center(sinogram, args.angles)
+        midpoint = sinogram.shape[1] / 2.0
+        print(f"  Rotation center: {center:.1f} (midpoint: {midpoint:.1f}, offset: {center - midpoint:.1f})")
+
+        # Shift sinogram so center of rotation is at detector midpoint
+        sinogram_centered = shift_sinogram_to_center(sinogram, center)
+
+        # 1. Raw FBP (no ring removal)
+        print("  Reconstructing raw FBP...")
+        recon_raw = reconstruct_fbp(sinogram_centered, args.angles)
+
+        # 2. SVD reference
+        recon_svd = None
+        if svd_path.exists():
+            print("  Reconstructing SVD reference FBP...")
+            sino_svd = load_tiff(svd_path)
+            sino_svd_centered = shift_sinogram_to_center(sino_svd, center)
+            recon_svd = reconstruct_fbp(sino_svd_centered, args.angles)
+
+        # 3. Streak mode (our fix) — denoise original, then shift for recon
+        print("  Running streak mode BM3D...")
+        sino_streak = bm3d_ring_artifact_removal(sinogram, mode="streak")
+        sino_streak_centered = shift_sinogram_to_center(sino_streak, center)
+        print("  Reconstructing streak FBP...")
+        recon_streak = reconstruct_fbp(sino_streak_centered, args.angles)
+
+        # Shared percentile bounds for fair comparison
+        all_recons = [recon_raw, recon_streak]
+        if recon_svd is not None:
+            all_recons.append(recon_svd)
+        combined = np.concatenate([r.ravel() for r in all_recons])
+        vmin, vmax = float(np.percentile(combined, 1)), float(np.percentile(combined, 99))
+
+        # Save individual images
+        raw_img = to_uint8(recon_raw, vmin, vmax)
+        streak_img = to_uint8(recon_streak, vmin, vmax)
+        Image.fromarray(raw_img).save(OUTPUT_DIR / f"recon_raw_slice{slice_id}.png")
+        Image.fromarray(streak_img).save(OUTPUT_DIR / f"recon_streak_slice{slice_id}.png")
+
+        panels = [raw_img, streak_img]
+        labels = ["Raw", "Streak"]
+
+        if recon_svd is not None:
+            svd_img = to_uint8(recon_svd, vmin, vmax)
+            Image.fromarray(svd_img).save(OUTPUT_DIR / f"recon_svd_slice{slice_id}.png")
+            panels.append(svd_img)
+            labels.append("SVD")
+
+        # Side-by-side comparison
+        max_h = max(p.shape[0] for p in panels)
+        max_w = max(p.shape[1] for p in panels)
+        gap = 4
+
+        total_w = len(panels) * max_w + (len(panels) - 1) * gap
+        canvas = np.zeros((max_h, total_w), dtype=np.uint8)
+
+        for i, panel in enumerate(panels):
+            x_off = i * (max_w + gap)
+            y_off = (max_h - panel.shape[0]) // 2
+            canvas[y_off : y_off + panel.shape[0], x_off : x_off + panel.shape[1]] = panel
+
+        comp_path = OUTPUT_DIR / f"comparison_slice{slice_id}.png"
+        Image.fromarray(canvas).save(comp_path)
+        print(f"  Saved: {comp_path}")
+        print(f"  Individual: recon_raw_slice{slice_id}.png, recon_streak_slice{slice_id}.png", end="")
+        if recon_svd is not None:
+            print(f", recon_svd_slice{slice_id}.png")
+        else:
+            print()
+
+    print(f"\nAll outputs in: {OUTPUT_DIR}/")
+    print("Compare Raw vs Streak vs SVD — look for center ring artifact in streak results.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reconstruct_and_compare.py
+++ b/scripts/reconstruct_and_compare.py
@@ -11,7 +11,7 @@ Output images are saved to output_recon/ for visual inspection.
 Usage:
     pixi run python scripts/reconstruct_and_compare.py
     pixi run python scripts/reconstruct_and_compare.py --slice 0140
-    pixi run python scripts/reconstruct_and_compare.py --center 2116.5 --angles 360
+    pixi run python scripts/reconstruct_and_compare.py --center 2100 --angles 180
 """
 
 import argparse

--- a/scripts/verify_psd_fix.py
+++ b/scripts/verify_psd_fix.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""Diagnostic script to verify the PSD symmetry fix for streak mode.
+
+Loads sinograms from sinogram_extract/, processes with streak mode,
+and compares column variance / center bias against SVD reference.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+try:
+    from PIL import Image
+except ImportError:
+    import tifffile  # type: ignore[import-untyped]
+
+    class _TiffReader:
+        @staticmethod
+        def open(path):
+            class _Img:
+                def __init__(self, arr):
+                    self._arr = arr
+
+                def __array__(self):
+                    return self._arr
+
+            return _Img(tifffile.imread(str(path)))
+
+    Image = _TiffReader  # type: ignore[misc,assignment]
+
+from bm3dornl.bm3d import bm3d_ring_artifact_removal
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "sinogram_extract"
+
+
+def load_tiff(path: Path) -> np.ndarray:
+    img = Image.open(path)
+    return np.array(img).astype(np.float32)
+
+
+def column_variance(sinogram: np.ndarray) -> np.ndarray:
+    """Variance along projection axis (axis=0) for each column."""
+    return np.var(sinogram, axis=0)
+
+
+def center_bias_metric(col_var: np.ndarray, margin_frac: float = 0.25) -> float:
+    """Ratio of center column variance to edge column variance.
+
+    Values close to 1.0 indicate no center artifact.
+    Values >> 1.0 indicate center artifact (excess variance at center).
+    """
+    n = len(col_var)
+    margin = int(n * margin_frac)
+    if margin < 1:
+        margin = 1
+    edge_var = np.mean(np.concatenate([col_var[:margin], col_var[-margin:]]))
+    center_var = np.mean(col_var[margin:-margin])
+    if edge_var == 0:
+        return float("inf")
+    return float(center_var / edge_var)
+
+
+def main():
+    if not DATA_DIR.exists():
+        print(f"Data directory not found: {DATA_DIR}")
+        print("Place sinogram TIFF files in sinogram_extract/ to run this verification.")
+        sys.exit(1)
+
+    pre_files = sorted(DATA_DIR.glob("sino_pre_ring_slice*.tiff"))
+    svd_files = sorted(DATA_DIR.glob("sino_post_ring_svd_slice*.tiff"))
+
+    if not pre_files:
+        print("No pre-ring sinograms found in sinogram_extract/")
+        sys.exit(1)
+
+    print(f"Found {len(pre_files)} pre-ring sinograms, {len(svd_files)} SVD references")
+    print("=" * 72)
+
+    all_pass = True
+
+    for pre_path in pre_files:
+        slice_id = pre_path.stem.replace("sino_pre_ring_slice", "")
+        svd_path = DATA_DIR / f"sino_post_ring_svd_slice{slice_id}.tiff"
+
+        print(f"\nSlice {slice_id}:")
+
+        sinogram = load_tiff(pre_path)
+        print(f"  Input shape: {sinogram.shape}, range: [{sinogram.min():.4f}, {sinogram.max():.4f}]")
+
+        # Process with streak mode
+        streak_result = bm3d_ring_artifact_removal(sinogram, mode="streak")
+
+        streak_col_var = column_variance(streak_result)
+        streak_bias = center_bias_metric(streak_col_var)
+        print(f"  Streak mode center bias: {streak_bias:.4f}")
+
+        if svd_path.exists():
+            svd_ref = load_tiff(svd_path)
+            svd_col_var = column_variance(svd_ref)
+            svd_bias = center_bias_metric(svd_col_var)
+            print(f"  SVD reference center bias: {svd_bias:.4f}")
+            ratio = streak_bias / svd_bias if svd_bias > 0 else float("inf")
+            print(f"  Streak/SVD bias ratio: {ratio:.4f}")
+
+            # Pass if streak bias is within 2x of SVD bias
+            if ratio > 2.0:
+                print(f"  ** WARN: streak bias ratio {ratio:.2f}x exceeds 2.0x threshold **")
+                all_pass = False
+            else:
+                print("  OK")
+        else:
+            print("  (no SVD reference available)")
+            # Without reference, just check bias isn't extreme
+            if streak_bias > 3.0:
+                print(f"  ** WARN: streak center bias {streak_bias:.2f} seems high **")
+                all_pass = False
+            else:
+                print("  OK")
+
+    print("\n" + "=" * 72)
+    if all_pass:
+        print("PASS: No center artifact detected in streak mode results.")
+    else:
+        print("WARN: Some slices show elevated center bias. Review results above.")
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_psd_fix.py
+++ b/scripts/verify_psd_fix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Diagnostic script to verify the PSD symmetry fix for streak mode.
 
 Loads sinograms from sinogram_extract/, processes with streak mode,
@@ -13,21 +13,27 @@ import numpy as np
 try:
     from PIL import Image
 except ImportError:
-    import tifffile  # type: ignore[import-untyped]
+    try:
+        import tifffile  # type: ignore[import-untyped]
 
-    class _TiffReader:
-        @staticmethod
-        def open(path):
-            class _Img:
-                def __init__(self, arr):
-                    self._arr = arr
+        class _TiffReader:
+            @staticmethod
+            def open(path):
+                class _Img:
+                    def __init__(self, arr):
+                        self._arr = arr
 
-                def __array__(self):
-                    return self._arr
+                    def __array__(self):
+                        return self._arr
 
-            return _Img(tifffile.imread(str(path)))
+                return _Img(tifffile.imread(str(path)))
 
-    Image = _TiffReader  # type: ignore[misc,assignment]
+        Image = _TiffReader  # type: ignore[misc,assignment]
+    except ImportError as e:
+        raise ImportError(
+            "Neither Pillow (PIL) nor tifffile is installed. "
+            "Install one of them to run this script: pip install Pillow"
+        ) from e
 
 from bm3dornl.bm3d import bm3d_ring_artifact_removal
 

--- a/src/bm3dornl/bm3d.py
+++ b/src/bm3dornl/bm3d.py
@@ -246,7 +246,8 @@ def bm3d_ring_artifact_removal(
     if mode == "streak" and patch_size > 0:
         sigma_psd = np.zeros((patch_size, patch_size), dtype=np.float32)
         y_coords = np.arange(patch_size)
-        psd_profile = np.exp(-0.5 * (y_coords / psd_width) ** 2)
+        freq_dist = np.minimum(y_coords, patch_size - y_coords)
+        psd_profile = np.exp(-0.5 * (freq_dist / psd_width) ** 2)
         for x in range(patch_size):
             sigma_psd[:, x] = psd_profile
         sigma_psd = sigma_psd.astype(np.float32)

--- a/src/bm3dornl/bm3d.py
+++ b/src/bm3dornl/bm3d.py
@@ -244,6 +244,8 @@ def bm3d_ring_artifact_removal(
     # Prepare PSD (Shared)
     sigma_psd = np.zeros((1, 1), dtype=np.float32)
     if mode == "streak" and patch_size > 0:
+        if psd_width <= 0:
+            raise ValueError("psd_width must be > 0")
         sigma_psd = np.zeros((patch_size, patch_size), dtype=np.float32)
         y_coords = np.arange(patch_size)
         freq_dist = np.minimum(y_coords, patch_size - y_coords)

--- a/src/rust_core/crates/bm3d_core/src/orchestration.rs
+++ b/src/rust_core/crates/bm3d_core/src/orchestration.rs
@@ -194,6 +194,9 @@ impl<F: Bm3dFloat> Bm3dConfig<F> {
         if self.notch_width <= F::zero() {
             return Err("notch_width must be > 0".to_string());
         }
+        if self.psd_width <= F::zero() {
+            return Err("psd_width must be > 0".to_string());
+        }
         Ok(())
     }
 }
@@ -636,6 +639,21 @@ mod tests {
     fn test_config_validation_negative_sigma() {
         let config = Bm3dConfig {
             sigma_random: -0.1,
+            ..Bm3dConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_config_validation_invalid_psd_width() {
+        let config = Bm3dConfig {
+            psd_width: 0.0,
+            ..Bm3dConfig::default()
+        };
+        assert!(config.validate().is_err());
+
+        let config = Bm3dConfig {
+            psd_width: -0.1,
             ..Bm3dConfig::default()
         };
         assert!(config.validate().is_err());

--- a/src/rust_core/crates/bm3d_core/src/orchestration.rs
+++ b/src/rust_core/crates/bm3d_core/src/orchestration.rs
@@ -256,16 +256,19 @@ fn compute_sigma_map<F: Bm3dFloat>(
 
 /// Construct anisotropic PSD for streak mode.
 ///
-/// Creates a 2D array with Gaussian profile along Y-axis (rows),
-/// replicated across X-axis (columns). This models vertical streak noise.
+/// Creates a 2D array with FFT-symmetric Gaussian profile along Y-axis (rows),
+/// replicated across X-axis (columns). Uses circular frequency distance
+/// `min(y, N-y)` so that conjugate FFT bins share the same PSD value,
+/// preserving Hermitian symmetry. This models vertical streak noise.
 fn construct_psd<F: Bm3dFloat>(patch_size: usize, psd_width: F) -> Array2<F> {
     let mut sigma_psd = Array2::zeros((patch_size, patch_size));
 
     // Gaussian profile along Y-axis
     let neg_half = F::from_f64_c(-0.5);
     for y in 0..patch_size {
-        let y_f = F::usize_as(y);
-        let normalized = y_f / psd_width;
+        let freq_dist = y.min(patch_size - y);
+        let freq_dist_f = F::usize_as(freq_dist);
+        let normalized = freq_dist_f / psd_width;
         let value = (neg_half * normalized * normalized).exp();
 
         // Replicate across X-axis
@@ -701,9 +704,22 @@ mod tests {
         let psd = construct_psd::<f32>(8, 0.6);
         assert!(approx_eq(psd[[0, 0]], 1.0, 1e-6));
 
-        // Values should decrease as y increases
-        for y in 1..8 {
-            assert!(psd[[y, 0]] < psd[[y - 1, 0]], "PSD should decrease with y");
+        // Values should decrease from DC (y=0) to Nyquist (y=4),
+        // then increase symmetrically back toward DC
+        let nyquist = 4; // patch_size / 2
+        for y in 1..=nyquist {
+            assert!(
+                psd[[y, 0]] < psd[[y - 1, 0]],
+                "PSD should decrease from DC to Nyquist at y={}",
+                y
+            );
+        }
+        for y in (nyquist + 1)..8 {
+            assert!(
+                psd[[y, 0]] > psd[[y - 1, 0]],
+                "PSD should increase from Nyquist back to DC at y={}",
+                y
+            );
         }
     }
 
@@ -712,6 +728,65 @@ mod tests {
         let psd = construct_psd::<f32>(8, 0.6);
         for &val in psd.iter() {
             assert!(val > 0.0, "PSD values should be positive");
+        }
+    }
+
+    #[test]
+    fn test_psd_fft_symmetry() {
+        // In FFT layout, psd[y] must equal psd[N-y] for all y
+        for &patch_size in &[4usize, 8, 16] {
+            let psd = construct_psd::<f32>(patch_size, 0.6);
+            for y in 1..patch_size {
+                let mirror = patch_size - y;
+                assert!(
+                    approx_eq(psd[[y, 0]], psd[[mirror, 0]], 1e-6),
+                    "PSD symmetry broken: psd[{},0]={} != psd[{},0]={} for patch_size={}",
+                    y,
+                    psd[[y, 0]],
+                    mirror,
+                    psd[[mirror, 0]],
+                    patch_size,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_psd_symmetry_known_values() {
+        // For patch_size=8, psd_width=0.6:
+        // freq_dist for y=1 is min(1,7)=1, for y=7 is min(7,1)=1 → same value
+        let psd = construct_psd::<f32>(8, 0.6);
+        let expected_bin1 = (-0.5_f32 * (1.0_f32 / 0.6).powi(2)).exp();
+        assert!(
+            approx_eq(psd[[1, 0]], expected_bin1, 1e-6),
+            "Bin 1: expected {} got {}",
+            expected_bin1,
+            psd[[1, 0]]
+        );
+        assert!(
+            approx_eq(psd[[7, 0]], expected_bin1, 1e-6),
+            "Bin 7 should equal Bin 1: expected {} got {}",
+            expected_bin1,
+            psd[[7, 0]]
+        );
+    }
+
+    #[test]
+    fn test_psd_odd_patch_size_symmetry() {
+        for &patch_size in &[5usize, 7, 9] {
+            let psd = construct_psd::<f32>(patch_size, 0.6);
+            for y in 1..patch_size {
+                let mirror = patch_size - y;
+                assert!(
+                    approx_eq(psd[[y, 0]], psd[[mirror, 0]], 1e-6),
+                    "Odd patch_size={}: psd[{},0]={} != psd[{},0]={}",
+                    patch_size,
+                    y,
+                    psd[[y, 0]],
+                    mirror,
+                    psd[[mirror, 0]],
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes asymmetric PSD in streak mode that caused center artifact in CT reconstructions (issue #98)
- `construct_psd()` used raw FFT bin index `y` instead of circular frequency distance `min(y, N-y)`, so conjugate bins had different PSD values, breaking Hermitian symmetry
- Fix applied to both Rust (`orchestration.rs`) and Python (`bm3d.py`) PSD construction
- Added 3 new Rust tests for FFT symmetry, known values, and odd patch sizes
- Added diagnostic verification script (`scripts/verify_psd_fix.py`)

## Test plan
- [x] `pixi run lint` — cargo fmt + clippy clean
- [x] `pixi run build` — maturin compiles
- [x] `pixi run test-rust` — 170/170 passed (including new symmetry tests)
- [x] `pixi run test-python` — 47/47 passed
- [ ] Visual inspection of FBP reconstruction on real sinograms

🤖 Generated with [Claude Code](https://claude.com/claude-code)