### PR TITLE
fix(rust): finish edition-2024 unsafe_op_in_unsafe_fn migration in bm3d_core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main, next, qa]
   push:
     branches: [main, next, qa]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,15 @@ jobs:
           cargo test -p bm3d_core --release
 
   rust-lint:
-    name: Rust Lint
-    runs-on: ubuntu-latest
+    name: Rust Lint (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Lint on both x86_64 and aarch64 so the arch-gated SIMD paths are all
+        # covered: SSE2/AVX2 compile only on x86, NEON only on aarch64. A single-arch
+        # gate let the edition-2024 unsafe_op_in_unsafe_fn break hide on x86. See #109.
+        os: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v6
 
@@ -51,9 +58,10 @@ jobs:
         working-directory: src/rust_core
         run: cargo fmt --all -- --check
 
-      - name: Run clippy (bm3d_core only)
+      - name: Run clippy (entire workspace)
         working-directory: src/rust_core
-        run: cargo clippy -p bm3d_core -- -D warnings
+        # Lint every crate (bm3d_core, bm3d_python, bm3d_gui_egui), not just bm3d_core.
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   python-test:
     name: Python Tests

--- a/src/rust_core/crates/bm3d_core/src/block_matching.rs
+++ b/src/rust_core/crates/bm3d_core/src/block_matching.rs
@@ -216,41 +216,47 @@ unsafe fn compute_squared_distance_at_strided_8x8_f32_sse2(
     cand_c: usize,
     threshold: f32,
 ) -> f32 {
-    let mut sum_sq = 0.0f32;
-    for dr in 0..8 {
-        let ref_base = (ref_r + dr) * image_cols + ref_c;
-        let cand_base = (cand_r + dr) * image_cols + cand_c;
-        let ref_ptr = image_data.as_ptr().add(ref_base);
-        let cand_ptr = image_data.as_ptr().add(cand_base);
+    // SAFETY: The required SIMD feature (SSE2) is runtime-checked by
+    // `compute_squared_distance_at_strided_8x8_f32_dispatch` before this function is
+    // called, and callers only pass block positions whose strided 8x8 window lies
+    // fully within `image_data`, so every pointer `add`/load stays in bounds.
+    unsafe {
+        let mut sum_sq = 0.0f32;
+        for dr in 0..8 {
+            let ref_base = (ref_r + dr) * image_cols + ref_c;
+            let cand_base = (cand_r + dr) * image_cols + cand_c;
+            let ref_ptr = image_data.as_ptr().add(ref_base);
+            let cand_ptr = image_data.as_ptr().add(cand_base);
 
-        let ref_lo = _mm_loadu_ps(ref_ptr);
-        let cand_lo = _mm_loadu_ps(cand_ptr);
-        let diff_lo = _mm_sub_ps(ref_lo, cand_lo);
-        let sq_lo = _mm_mul_ps(diff_lo, diff_lo);
+            let ref_lo = _mm_loadu_ps(ref_ptr);
+            let cand_lo = _mm_loadu_ps(cand_ptr);
+            let diff_lo = _mm_sub_ps(ref_lo, cand_lo);
+            let sq_lo = _mm_mul_ps(diff_lo, diff_lo);
 
-        let ref_hi = _mm_loadu_ps(ref_ptr.add(4));
-        let cand_hi = _mm_loadu_ps(cand_ptr.add(4));
-        let diff_hi = _mm_sub_ps(ref_hi, cand_hi);
-        let sq_hi = _mm_mul_ps(diff_hi, diff_hi);
+            let ref_hi = _mm_loadu_ps(ref_ptr.add(4));
+            let cand_hi = _mm_loadu_ps(cand_ptr.add(4));
+            let diff_hi = _mm_sub_ps(ref_hi, cand_hi);
+            let sq_hi = _mm_mul_ps(diff_hi, diff_hi);
 
-        let mut lanes_lo = [0.0f32; 4];
-        let mut lanes_hi = [0.0f32; 4];
-        _mm_storeu_ps(lanes_lo.as_mut_ptr(), sq_lo);
-        _mm_storeu_ps(lanes_hi.as_mut_ptr(), sq_hi);
+            let mut lanes_lo = [0.0f32; 4];
+            let mut lanes_hi = [0.0f32; 4];
+            _mm_storeu_ps(lanes_lo.as_mut_ptr(), sq_lo);
+            _mm_storeu_ps(lanes_hi.as_mut_ptr(), sq_hi);
 
-        sum_sq += lanes_lo[0]
-            + lanes_lo[1]
-            + lanes_lo[2]
-            + lanes_lo[3]
-            + lanes_hi[0]
-            + lanes_hi[1]
-            + lanes_hi[2]
-            + lanes_hi[3];
-        if sum_sq >= threshold {
-            return sum_sq;
+            sum_sq += lanes_lo[0]
+                + lanes_lo[1]
+                + lanes_lo[2]
+                + lanes_lo[3]
+                + lanes_hi[0]
+                + lanes_hi[1]
+                + lanes_hi[2]
+                + lanes_hi[3];
+            if sum_sq >= threshold {
+                return sum_sq;
+            }
         }
+        sum_sq
     }
-    sum_sq
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -264,27 +270,39 @@ unsafe fn compute_squared_distance_at_strided_8x8_f32_avx2(
     cand_c: usize,
     threshold: f32,
 ) -> f32 {
-    let mut sum_sq = 0.0f32;
-    for dr in 0..8 {
-        let ref_base = (ref_r + dr) * image_cols + ref_c;
-        let cand_base = (cand_r + dr) * image_cols + cand_c;
-        let ref_ptr = image_data.as_ptr().add(ref_base);
-        let cand_ptr = image_data.as_ptr().add(cand_base);
+    // SAFETY: The required SIMD feature (AVX2) is runtime-checked by
+    // `compute_squared_distance_at_strided_8x8_f32_dispatch` before this function is
+    // called, and callers only pass block positions whose strided 8x8 window lies
+    // fully within `image_data`, so every pointer `add`/load stays in bounds.
+    unsafe {
+        let mut sum_sq = 0.0f32;
+        for dr in 0..8 {
+            let ref_base = (ref_r + dr) * image_cols + ref_c;
+            let cand_base = (cand_r + dr) * image_cols + cand_c;
+            let ref_ptr = image_data.as_ptr().add(ref_base);
+            let cand_ptr = image_data.as_ptr().add(cand_base);
 
-        let ref_vec = _mm256_loadu_ps(ref_ptr);
-        let cand_vec = _mm256_loadu_ps(cand_ptr);
-        let diff = _mm256_sub_ps(ref_vec, cand_vec);
-        let sq = _mm256_mul_ps(diff, diff);
+            let ref_vec = _mm256_loadu_ps(ref_ptr);
+            let cand_vec = _mm256_loadu_ps(cand_ptr);
+            let diff = _mm256_sub_ps(ref_vec, cand_vec);
+            let sq = _mm256_mul_ps(diff, diff);
 
-        let mut lanes = [0.0f32; 8];
-        _mm256_storeu_ps(lanes.as_mut_ptr(), sq);
-        sum_sq +=
-            lanes[0] + lanes[1] + lanes[2] + lanes[3] + lanes[4] + lanes[5] + lanes[6] + lanes[7];
-        if sum_sq >= threshold {
-            return sum_sq;
+            let mut lanes = [0.0f32; 8];
+            _mm256_storeu_ps(lanes.as_mut_ptr(), sq);
+            sum_sq += lanes[0]
+                + lanes[1]
+                + lanes[2]
+                + lanes[3]
+                + lanes[4]
+                + lanes[5]
+                + lanes[6]
+                + lanes[7];
+            if sum_sq >= threshold {
+                return sum_sq;
+            }
         }
+        sum_sq
     }
-    sum_sq
 }
 
 #[cfg(target_arch = "aarch64")]

--- a/src/rust_core/crates/bm3d_core/src/block_matching.rs
+++ b/src/rust_core/crates/bm3d_core/src/block_matching.rs
@@ -216,10 +216,10 @@ unsafe fn compute_squared_distance_at_strided_8x8_f32_sse2(
     cand_c: usize,
     threshold: f32,
 ) -> f32 {
-    // SAFETY: The required SIMD feature (SSE2) is runtime-checked by
+    // SAFETY: SSE2 is guaranteed baseline on x86_64 and runtime-checked on x86 by
     // `compute_squared_distance_at_strided_8x8_f32_dispatch` before this function is
-    // called, and callers only pass block positions whose strided 8x8 window lies
-    // fully within `image_data`, so every pointer `add`/load stays in bounds.
+    // called. Callers only pass block positions whose full strided 8x8 window (both
+    // `ref` and `cand`) lies within `image_data`, so every pointer `add`/load is in bounds.
     unsafe {
         let mut sum_sq = 0.0f32;
         for dr in 0..8 {

--- a/src/rust_core/crates/bm3d_core/src/pipeline.rs
+++ b/src/rust_core/crates/bm3d_core/src/pipeline.rs
@@ -1054,10 +1054,11 @@ unsafe fn aggregate_patch_row8_avx2(
     local_c0: usize,
     weight: f32,
 ) {
-    // SAFETY: The required SIMD feature (AVX2) is runtime-checked by
-    // `try_aggregate_patch_row8_simd_f32` before this function is called, which also
-    // verifies `local_c0 + 8 <= tile_w`; the buffers are contiguous and sized for the
-    // tile, so every pointer `add`/load/store stays in bounds.
+    // SAFETY: AVX2 is runtime-checked by `try_aggregate_patch_row8_simd_f32` before this
+    // function is called, which also verifies the column bound `local_c0 + 8 <= tile_w`.
+    // Its caller only aggregates patches whose full 8x8 window (rows `local_r0..+8`, cols
+    // `local_c0..+8`) lies within the contiguous, tile-sized `num_data`/`den_data`
+    // buffers, so every pointer `add`/load/store stays in bounds.
     unsafe {
         use std::arch::x86_64::*;
         let wv = _mm256_set1_ps(weight);
@@ -1089,10 +1090,11 @@ unsafe fn aggregate_patch_row8_sse2(
     local_c0: usize,
     weight: f32,
 ) {
-    // SAFETY: The required SIMD feature (SSE2) is runtime-checked by
-    // `try_aggregate_patch_row8_simd_f32` before this function is called, which also
-    // verifies `local_c0 + 8 <= tile_w`; the buffers are contiguous and sized for the
-    // tile, so every pointer `add`/load/store stays in bounds.
+    // SAFETY: SSE2 is runtime-checked by `try_aggregate_patch_row8_simd_f32` before this
+    // function is called, which also verifies the column bound `local_c0 + 8 <= tile_w`.
+    // Its caller only aggregates patches whose full 8x8 window (rows `local_r0..+8`, cols
+    // `local_c0..+8`) lies within the contiguous, tile-sized `num_data`/`den_data`
+    // buffers, so every pointer `add`/load/store stays in bounds.
     unsafe {
         use std::arch::x86_64::*;
         let wv = _mm_set1_ps(weight);
@@ -1127,9 +1129,11 @@ unsafe fn aggregate_patch_row8_neon(
     local_c0: usize,
     weight: f32,
 ) {
-    // SAFETY: NEON is baseline on aarch64; `try_aggregate_patch_row8_simd_f32` verifies
-    // `local_c0 + 8 <= tile_w` before calling, and the buffers are contiguous and sized
-    // for the tile, so every pointer `add`/load/store stays in bounds.
+    // SAFETY: NEON is baseline on aarch64; `try_aggregate_patch_row8_simd_f32` verifies the
+    // column bound `local_c0 + 8 <= tile_w` before calling. Its caller only aggregates
+    // patches whose full 8x8 window (rows `local_r0..+8`, cols `local_c0..+8`) lies within
+    // the contiguous, tile-sized `num_data`/`den_data` buffers, so every `add`/load/store
+    // stays in bounds.
     unsafe {
         use std::arch::aarch64::*;
         let wv = vdupq_n_f32(weight);

--- a/src/rust_core/crates/bm3d_core/src/pipeline.rs
+++ b/src/rust_core/crates/bm3d_core/src/pipeline.rs
@@ -1043,7 +1043,6 @@ fn get_or_insert_tile<F: Bm3dFloat>(
 }
 
 #[cfg(target_arch = "x86_64")]
-#[allow(unsafe_op_in_unsafe_fn)]
 #[target_feature(enable = "avx2")]
 unsafe fn aggregate_patch_row8_avx2(
     num_data: &mut [f32],
@@ -1055,25 +1054,30 @@ unsafe fn aggregate_patch_row8_avx2(
     local_c0: usize,
     weight: f32,
 ) {
-    use std::arch::x86_64::*;
-    let wv = _mm256_set1_ps(weight);
-    for pr in 0..8 {
-        let src_base = pr * 8;
-        let dst_base = (local_r0 + pr) * tile_w + local_c0;
-        let s = _mm256_loadu_ps(spatial_vals.as_ptr().add(src_base));
-        let b = _mm256_loadu_ps(blend_vals.as_ptr().add(src_base));
-        let wr = _mm256_mul_ps(b, wv);
-        let num = _mm256_loadu_ps(num_data.as_ptr().add(dst_base));
-        let den = _mm256_loadu_ps(den_data.as_ptr().add(dst_base));
-        let num_new = _mm256_add_ps(num, _mm256_mul_ps(s, wr));
-        let den_new = _mm256_add_ps(den, wr);
-        _mm256_storeu_ps(num_data.as_mut_ptr().add(dst_base), num_new);
-        _mm256_storeu_ps(den_data.as_mut_ptr().add(dst_base), den_new);
+    // SAFETY: The required SIMD feature (AVX2) is runtime-checked by
+    // `try_aggregate_patch_row8_simd_f32` before this function is called, which also
+    // verifies `local_c0 + 8 <= tile_w`; the buffers are contiguous and sized for the
+    // tile, so every pointer `add`/load/store stays in bounds.
+    unsafe {
+        use std::arch::x86_64::*;
+        let wv = _mm256_set1_ps(weight);
+        for pr in 0..8 {
+            let src_base = pr * 8;
+            let dst_base = (local_r0 + pr) * tile_w + local_c0;
+            let s = _mm256_loadu_ps(spatial_vals.as_ptr().add(src_base));
+            let b = _mm256_loadu_ps(blend_vals.as_ptr().add(src_base));
+            let wr = _mm256_mul_ps(b, wv);
+            let num = _mm256_loadu_ps(num_data.as_ptr().add(dst_base));
+            let den = _mm256_loadu_ps(den_data.as_ptr().add(dst_base));
+            let num_new = _mm256_add_ps(num, _mm256_mul_ps(s, wr));
+            let den_new = _mm256_add_ps(den, wr);
+            _mm256_storeu_ps(num_data.as_mut_ptr().add(dst_base), num_new);
+            _mm256_storeu_ps(den_data.as_mut_ptr().add(dst_base), den_new);
+        }
     }
 }
 
 #[cfg(target_arch = "x86_64")]
-#[allow(unsafe_op_in_unsafe_fn)]
 #[target_feature(enable = "sse2")]
 unsafe fn aggregate_patch_row8_sse2(
     num_data: &mut [f32],
@@ -1085,29 +1089,34 @@ unsafe fn aggregate_patch_row8_sse2(
     local_c0: usize,
     weight: f32,
 ) {
-    use std::arch::x86_64::*;
-    let wv = _mm_set1_ps(weight);
-    for pr in 0..8 {
-        let src_base = pr * 8;
-        let dst_base = (local_r0 + pr) * tile_w + local_c0;
-        for offset in [0usize, 4usize] {
-            let src = src_base + offset;
-            let dst = dst_base + offset;
-            let s = _mm_loadu_ps(spatial_vals.as_ptr().add(src));
-            let b = _mm_loadu_ps(blend_vals.as_ptr().add(src));
-            let wr = _mm_mul_ps(b, wv);
-            let num = _mm_loadu_ps(num_data.as_ptr().add(dst));
-            let den = _mm_loadu_ps(den_data.as_ptr().add(dst));
-            let num_new = _mm_add_ps(num, _mm_mul_ps(s, wr));
-            let den_new = _mm_add_ps(den, wr);
-            _mm_storeu_ps(num_data.as_mut_ptr().add(dst), num_new);
-            _mm_storeu_ps(den_data.as_mut_ptr().add(dst), den_new);
+    // SAFETY: The required SIMD feature (SSE2) is runtime-checked by
+    // `try_aggregate_patch_row8_simd_f32` before this function is called, which also
+    // verifies `local_c0 + 8 <= tile_w`; the buffers are contiguous and sized for the
+    // tile, so every pointer `add`/load/store stays in bounds.
+    unsafe {
+        use std::arch::x86_64::*;
+        let wv = _mm_set1_ps(weight);
+        for pr in 0..8 {
+            let src_base = pr * 8;
+            let dst_base = (local_r0 + pr) * tile_w + local_c0;
+            for offset in [0usize, 4usize] {
+                let src = src_base + offset;
+                let dst = dst_base + offset;
+                let s = _mm_loadu_ps(spatial_vals.as_ptr().add(src));
+                let b = _mm_loadu_ps(blend_vals.as_ptr().add(src));
+                let wr = _mm_mul_ps(b, wv);
+                let num = _mm_loadu_ps(num_data.as_ptr().add(dst));
+                let den = _mm_loadu_ps(den_data.as_ptr().add(dst));
+                let num_new = _mm_add_ps(num, _mm_mul_ps(s, wr));
+                let den_new = _mm_add_ps(den, wr);
+                _mm_storeu_ps(num_data.as_mut_ptr().add(dst), num_new);
+                _mm_storeu_ps(den_data.as_mut_ptr().add(dst), den_new);
+            }
         }
     }
 }
 
 #[cfg(target_arch = "aarch64")]
-#[allow(unsafe_op_in_unsafe_fn)]
 unsafe fn aggregate_patch_row8_neon(
     num_data: &mut [f32],
     den_data: &mut [f32],
@@ -1118,6 +1127,9 @@ unsafe fn aggregate_patch_row8_neon(
     local_c0: usize,
     weight: f32,
 ) {
+    // SAFETY: NEON is baseline on aarch64; `try_aggregate_patch_row8_simd_f32` verifies
+    // `local_c0 + 8 <= tile_w` before calling, and the buffers are contiguous and sized
+    // for the tile, so every pointer `add`/load/store stays in bounds.
     unsafe {
         use std::arch::aarch64::*;
         let wv = vdupq_n_f32(weight);


### PR DESCRIPTION
## What & why

Finishes the Rust **edition-2024 migration** in `bm3d_core` that #95 left incomplete. The `unsafe_op_in_unsafe_fn` lint (warn-by-default in edition 2024, escalated to an error by our `clippy -D warnings` gate) was handled **three inconsistent ways**, leaving `Rust Lint` red on `next` since the edition bump and masking the same issue elsewhere.

Closes #109.

## Changes

**Source — wrap unsafe ops in `unsafe {}` (the [recommended migration](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html), not a side-step):**
- `block_matching.rs` — wrap the SSE2 (L210) & AVX2 (L258) bodies (the 15 `E0133` failures), with `// SAFETY:` notes.
- `pipeline.rs` — wrap the AVX2 & SSE2 bodies; **remove all 3 `#[allow(unsafe_op_in_unsafe_fn)]`** (the NEON one was redundant — its body was already wrapped).
- **Zero `#[allow(unsafe_op_in_unsafe_fn)]` remain** in the crate.

**CI — close the blind spot that let this hide:**
- Lint the **entire workspace** (`bm3d_core`, `bm3d_python`, `bm3d_gui_egui`) — previously only `bm3d_core`.
- Lint on **both x86_64 and aarch64** (matrix) — previously x86 only, which is exactly why the SSE2/AVX2 break was invisible to a NEON-only dev box and the NEON path is invisible to x86 CI.

## Verification

Locally on **aarch64** (NEON + scalar paths):
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean
- `cargo test -p bm3d_core` → 171 + 2 passed, 0 failed (no behavior change)

The **x86 SSE2/AVX2** wrapping can't be compiled on the arm64 dev box (cfg-gated); it's the identical transform applied to the already-verified NEON pattern, and is confirmed by this PR's CI run on `ubuntu-latest`.

## Reviewer note

The lint job is renamed to `Rust Lint (<os>)` (matrix). `next` has no required status checks, so nothing is stranded — but if **`main`** has a required check named `Rust Lint`, that config will need updating before a promotion PR to `main` (the workflow also runs on `pull_request: [main]`).
