### PR TITLE
Bump rand to 0.8.6/0.9.3 (GHSA-cq8v-f236-94qc soundness fix)

### DIFF
--- a/src/rust_core/Cargo.lock
+++ b/src/rust_core/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.2",
+ "rand 0.9.3",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -553,7 +553,7 @@ dependencies = [
  "libc",
  "ndarray",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_distr",
  "rayon",
  "rustfft",
@@ -3014,9 +3014,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3025,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3078,7 +3078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4831,7 +4831,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_repr",
  "sha1",


### PR DESCRIPTION
## What

Bumps the transitive `rand` crate in `src/rust_core/Cargo.lock`:
- `rand` 0.8.5 → **0.8.6**
- `rand` 0.9.2 → **0.9.3**

## Why

Resolves two open **LOW**-severity Dependabot alerts (#6, #7), both [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc): *"Rand is unsound with a custom logger using rand::rng()."* The UB only manifests under a narrow combination (a custom `log` logger that itself calls `rand::rng()`/`RngCore` on `ThreadRng` and triggers a reseed mid-call), so practical impact for this app is negligible — but the fix is a trivial transitive patch bump.

## Scope / verification

- Lock-file only; no `Cargo.toml` constraint changes. Only the `rand` entries (and references to them) change — 140+ other deps untouched.
- `cargo check` on `src/rust_core` passes locally (exit 0).
- CI (test/build/gui) will validate further.

Found via the weekly security sweep (this repo had been missed by the auto-discovery, which only looked one level deep — being fixed separately).

Assisted-With: Claude Opus 4.8 (1M context)