### PR TITLE
fix(deps): bump pyo3 + numpy 0.25 → 0.29 (security)

### DIFF
--- a/src/rust_core/Cargo.lock
+++ b/src/rust_core/Cargo.lock
@@ -1918,15 +1918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1dee9aa8d3f6f8e8b9af3803006101bb3653866ef056d530d53ae68587191"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "libc",
  "ndarray",
@@ -2918,36 +2909,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2955,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2967,13 +2954,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.113",
 ]
@@ -3788,12 +3774,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "url"

--- a/src/rust_core/crates/bm3d_python/Cargo.toml
+++ b/src/rust_core/crates/bm3d_python/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bm3d_core = { path = "../bm3d_core" }
-pyo3 = { version = "0.25", features = ["extension-module"] }
-numpy = "0.25"
+pyo3 = { version = "0.29", features = ["extension-module"] }
+numpy = "0.29"
 ndarray = { workspace = true }

--- a/src/rust_core/crates/bm3d_python/src/lib.rs
+++ b/src/rust_core/crates/bm3d_python/src/lib.rs
@@ -26,9 +26,9 @@ const KEYBOARD_INTERRUPT_SENTINEL: &str = "KeyboardInterrupt:";
 ///
 /// KeyboardInterrupt is tagged with a sentinel prefix so it can be re-raised
 /// as `PyKeyboardInterrupt` instead of being swallowed into a generic `PyValueError`.
-fn make_progress_fn(cb: PyObject) -> ProgressFn {
+fn make_progress_fn(cb: Py<PyAny>) -> ProgressFn {
     Box::new(move |current: usize, total: usize| -> Result<(), String> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             cb.call(py, (current, total), None)
                 .map(|_| ())
                 .map_err(|e| {
@@ -206,14 +206,14 @@ pub fn bm3d_hard_thresholding_stack<'py>(
     step_size: usize,
     search_window: usize,
     max_matches: usize,
-    progress_callback: Option<PyObject>,
+    progress_callback: Option<Py<PyAny>>,
 ) -> PyResult<Bound<'py, PyArray3<f32>>> {
     let noisy = input_noisy.as_array().to_owned();
     let pilot = input_pilot.as_array().to_owned();
     let psd = sigma_psd.as_array().to_owned();
     let smap = sigma_map.as_array().to_owned();
     let plans = bm3d_core::pipeline::Bm3dPlans::new(patch_size, max_matches);
-    let output = py.allow_threads(|| {
+    let output = py.detach(|| {
         let progress_fn: Option<ProgressFn> = progress_callback.map(make_progress_fn);
         run_bm3d_step_stack_compat(
             noisy.view(),
@@ -249,14 +249,14 @@ pub fn bm3d_wiener_filtering_stack<'py>(
     step_size: usize,
     search_window: usize,
     max_matches: usize,
-    progress_callback: Option<PyObject>,
+    progress_callback: Option<Py<PyAny>>,
 ) -> PyResult<Bound<'py, PyArray3<f32>>> {
     let noisy = input_noisy.as_array().to_owned();
     let pilot = input_pilot.as_array().to_owned();
     let psd = sigma_psd.as_array().to_owned();
     let smap = sigma_map.as_array().to_owned();
     let plans = bm3d_core::pipeline::Bm3dPlans::new(patch_size, max_matches);
-    let output = py.allow_threads(|| {
+    let output = py.detach(|| {
         let progress_fn: Option<ProgressFn> = progress_callback.map(make_progress_fn);
         run_bm3d_step_stack_compat(
             noisy.view(),
@@ -399,14 +399,14 @@ pub fn bm3d_hard_thresholding_stack_f64<'py>(
     step_size: usize,
     search_window: usize,
     max_matches: usize,
-    progress_callback: Option<PyObject>,
+    progress_callback: Option<Py<PyAny>>,
 ) -> PyResult<Bound<'py, PyArray3<f64>>> {
     let noisy = input_noisy.as_array().to_owned();
     let pilot = input_pilot.as_array().to_owned();
     let psd = sigma_psd.as_array().to_owned();
     let smap = sigma_map.as_array().to_owned();
     let plans = bm3d_core::pipeline::Bm3dPlans::new(patch_size, max_matches);
-    let output = py.allow_threads(|| {
+    let output = py.detach(|| {
         let progress_fn: Option<ProgressFn> = progress_callback.map(make_progress_fn);
         run_bm3d_step_stack_compat(
             noisy.view(),
@@ -442,14 +442,14 @@ pub fn bm3d_wiener_filtering_stack_f64<'py>(
     step_size: usize,
     search_window: usize,
     max_matches: usize,
-    progress_callback: Option<PyObject>,
+    progress_callback: Option<Py<PyAny>>,
 ) -> PyResult<Bound<'py, PyArray3<f64>>> {
     let noisy = input_noisy.as_array().to_owned();
     let pilot = input_pilot.as_array().to_owned();
     let psd = sigma_psd.as_array().to_owned();
     let smap = sigma_map.as_array().to_owned();
     let plans = bm3d_core::pipeline::Bm3dPlans::new(patch_size, max_matches);
-    let output = py.allow_threads(|| {
+    let output = py.detach(|| {
         let progress_fn: Option<ProgressFn> = progress_callback.map(make_progress_fn);
         run_bm3d_step_stack_compat(
             noisy.view(),


### PR DESCRIPTION
## What

Bumps `pyo3` and the rust `numpy` crate in `bm3d_python` from **0.25 → 0.29** to clear the Dependabot advisories from the 2026-06-15 security sweep:

- **HIGH** — out-of-bounds read in `nth`/`nth_back` for `PyList`/`PyTuple`
- **MEDIUM** — missing `Sync` bound on `PyCFunction::new_closure` closures

Both are first patched in **pyo3 0.29.0**; `bm3d_python` pinned `"0.25"`. `numpy` is bumped in lockstep (numpy 0.29 requires pyo3 0.29).

## Migration

`bm3d_python` was already written against the modern Bound API (`#[pymodule] fn bm3d_rust(m: &Bound<'_, PyModule>)`, `Bound<'py, T>`, `PyReadonlyArray*`), so the four-minor-version jump needed only mechanical fixes for the pyo3 GIL-API rename and the `PyObject` removal — **20 lines in `lib.rs`**:

- `Python::with_gil` → `Python::attach`
- `py.allow_threads` → `py.detach` (×4)
- `PyObject` → `Py<PyAny>` (×5; `PyObject` was removed in 0.29)

No `numpy`-crate API changes were needed (`PyArray*`/`PyReadonlyArray*`/`ToPyArray` unchanged).

## Validation (all CI gates, run locally)

- `pixi run build` (maturin develop --release) — builds against pyo3/numpy 0.29.0 (CPython 3.12). ✅
- `pixi run test-python` — **47 passed, 1 skipped**. ✅
- `cargo test --workspace` (test-rust) — green. ✅
- `cargo fmt --all -- --check` — clean. ✅
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (incl. `bm3d_python`). ✅

Diff is `Cargo.toml` + `Cargo.lock` + `lib.rs` only; the incidental `pixi.lock` env-solve churn was reverted to keep this focused on the dependency fix.

🤖 Assisted with [Claude Code](https://claude.com/claude-code)