### PR TITLE
[codex] Fix large TIFF export and sync BM3D defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Changed the public Python default for `bm3d_ring_artifact_removal` from `mode="generic"` to `mode="streak"` so the API default matches the package's ring-artifact removal focus and the GUI/default documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 - Changed the public Python default for `bm3d_ring_artifact_removal` from `mode="generic"` to `mode="streak"` so the API default matches the package's ring-artifact removal focus and the GUI/default documentation.
+- Changed the public Python `threshold` default to `None` so single-scale processing uses the Rust default `2.7` and multi-scale processing uses the Rust multi-scale default `3.5` unless callers provide an explicit threshold.

--- a/README.md
+++ b/README.md
@@ -185,11 +185,11 @@ Parameter Reference
 | `mode` | `"streak"` | `"generic"` for white noise, `"streak"` for ring artifacts |
 | `sigma_random` | `0.1` | Noise standard deviation |
 | `patch_size` | `8` | Patch size (7 or 8 recommended) |
-| `step_size` | `3` | Step size for patch extraction |
-| `search_window` | `39` | Maximum search distance for similar patches |
+| `step_size` | `4` | Step size for patch extraction |
+| `search_window` | `24` | Maximum search distance for similar patches |
 | `max_matches` | `16` | Maximum similar patches per 3D group |
 | `batch_size` | `32` | Batch size for stack processing |
-| `streak_sigma_smooth` | `1.0` | Smoothing for streak mode (streak mode only) |
+| `streak_sigma_smooth` | `3.0` | Smoothing for streak mode (streak mode only) |
 | `multiscale` | `False` | Enable multi-scale processing for wide streaks |
 | `num_scales` | `None` | Number of scales (auto-detected if None) |
 | `filter_strength` | `1.0` | Filtering strength multiplier for multi-scale |

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -115,8 +115,9 @@ Advanced Parameters
      - Default
      - Description
    * - ``threshold``
-     - ``2.7``
-     - Hard thresholding coefficient for the first BM3D stage.
+     - ``None``
+     - Hard thresholding coefficient. ``None`` uses the backend default:
+       ``2.7`` for single-scale BM3D and ``3.5`` for multi-scale BM3D.
    * - ``batch_size``
      - ``32``
      - Chunk size for 3D stack processing (controls memory usage).

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -14,7 +14,7 @@ Mode Selection
      - Default
      - Description
    * - ``mode``
-     - ``"generic"``
+     - ``"streak"``
      - Operation mode. Use ``"generic"`` for white noise, ``"streak"`` for ring artifacts.
 
 .. note::

--- a/src/bm3dornl/bm3d.py
+++ b/src/bm3dornl/bm3d.py
@@ -7,7 +7,6 @@ from . import bm3d_rust
 from .bm3d_rust import estimate_streak_profile_rust
 
 DEFAULT_SINGLE_SCALE_THRESHOLD = 2.7
-DEFAULT_MULTISCALE_THRESHOLD = 3.5
 
 
 def estimate_streak_profile(sinogram, sigma_smooth=3.0, iterations=3):

--- a/src/bm3dornl/bm3d.py
+++ b/src/bm3dornl/bm3d.py
@@ -34,7 +34,7 @@ def estimate_streak_profile(sinogram, sigma_smooth=3.0, iterations=3):
 
 def bm3d_ring_artifact_removal(
     sinogram: np.ndarray,
-    mode: str = "generic",
+    mode: str = "streak",
     sigma_random: float = 0.1,
     patch_size: int = 8,
     step_size: int = 4,
@@ -70,7 +70,7 @@ def bm3d_ring_artifact_removal(
         Operation mode:
         - "generic": Standard BM3D (assume white noise).
         - "streak": Additive Streak Removal (Residual Median) + Standard BM3D.
-        By default "generic".
+        By default "streak".
     sigma_random : float, optional
         Random noise standard deviation, by default 0.1.
     patch_size : int, optional

--- a/src/bm3dornl/bm3d.py
+++ b/src/bm3dornl/bm3d.py
@@ -6,6 +6,9 @@ from scipy.ndimage import gaussian_filter1d
 from . import bm3d_rust
 from .bm3d_rust import estimate_streak_profile_rust
 
+DEFAULT_SINGLE_SCALE_THRESHOLD = 2.7
+DEFAULT_MULTISCALE_THRESHOLD = 3.5
+
 
 def estimate_streak_profile(sinogram, sigma_smooth=3.0, iterations=3):
     """
@@ -41,7 +44,7 @@ def bm3d_ring_artifact_removal(
     search_window: int = 24,
     max_matches: int = 16,
     batch_size: int = 32,
-    threshold: float = 2.7,
+    threshold: float | None = None,
     streak_sigma_smooth: float = 3.0,
     streak_iterations: int = 2,
     sigma_map_smoothing: float = 20.0,
@@ -83,8 +86,9 @@ def bm3d_ring_artifact_removal(
         Maximum number of similar patches per group, by default 16.
     batch_size : int, optional
         Chunk size for 3D stack processing, by default 32.
-    threshold : float, optional
-        Hard thresholding coefficient, by default 2.7.
+    threshold : float | None, optional
+        Hard thresholding coefficient. If None, the backend default is used:
+        2.7 for single-scale BM3D and 3.5 for multi-scale BM3D.
     streak_sigma_smooth : float, optional
         Sigma for smoothing in streak estimation, by default 3.0.
     streak_iterations : int, optional
@@ -313,7 +317,7 @@ def bm3d_ring_artifact_removal(
                 sigma_psd,
                 chunk_map,
                 sigma_random,
-                threshold,
+                DEFAULT_SINGLE_SCALE_THRESHOLD if threshold is None else threshold,
                 patch_size,
                 step_size,
                 search_window,

--- a/src/rust_core/crates/bm3d_core/README.md
+++ b/src/rust_core/crates/bm3d_core/README.md
@@ -34,17 +34,16 @@ let image: Array2<f32> = /* your image data */;
 
 // Configure BM3D for streak removal
 let config = Bm3dConfig {
-    mode: RingRemovalMode::Streak,
     sigma_random: 0.1,
     patch_size: 8,
-    step_size: 3,
-    search_window: 39,
+    step_size: 4,
+    search_window: 24,
     max_matches: 16,
     ..Default::default()
 };
 
 // Run denoising
-let denoised = bm3d_ring_artifact_removal(&image, &config);
+let denoised = bm3d_ring_artifact_removal(image.view(), RingRemovalMode::Streak, &config);
 ```
 
 ## Main API

--- a/src/rust_core/crates/bm3d_core/src/multiscale.rs
+++ b/src/rust_core/crates/bm3d_core/src/multiscale.rs
@@ -32,7 +32,7 @@ const MIN_SCALE_WIDTH: usize = 40;
 const BINNING_FACTOR: usize = 2;
 
 /// Default number of debinning iterations
-const DEFAULT_DEBIN_ITERATIONS: usize = 10;
+const DEFAULT_DEBIN_ITERATIONS: usize = 30;
 
 /// Default filter strength for multi-scale (reference uses 1.0)
 const DEFAULT_MULTISCALE_FILTER_STRENGTH: f64 = 1.0;
@@ -1290,7 +1290,7 @@ mod tests {
         assert!(config.num_scales.is_none());
         assert!(approx_eq(config.filter_strength, 1.0, 1e-6));
         assert!(approx_eq(config.threshold, 3.5, 1e-6));
-        assert_eq!(config.debin_iterations, 10);
+        assert_eq!(config.debin_iterations, 30);
     }
 
     #[test]

--- a/src/rust_core/crates/bm3d_core/src/orchestration.rs
+++ b/src/rust_core/crates/bm3d_core/src/orchestration.rs
@@ -24,8 +24,8 @@ use crate::streak::{estimate_streak_profile_impl, gaussian_blur_1d};
 // Constants
 // =============================================================================
 
-/// Default random noise standard deviation (0.0 = auto-estimate)
-const DEFAULT_SIGMA_RANDOM: f64 = 0.0;
+/// Default random noise standard deviation.
+const DEFAULT_SIGMA_RANDOM: f64 = 0.1;
 
 /// Default patch size for block matching
 const DEFAULT_PATCH_SIZE: usize = 8;
@@ -88,10 +88,10 @@ pub enum RingRemovalMode {
     Generic,
     /// Streak pre-subtraction + anisotropic PSD.
     /// Designed for ring artifact removal in sinograms.
+    #[default]
     Streak,
     /// Multi-scale BM3D with streak pre-subtraction.
     /// Handles wide streaks via pyramid processing.
-    #[default]
     MultiscaleStreak,
     /// Fourier-SVD algorithm.
     /// Uses FFT-guided energy detection with rank-1 SVD for streak removal.
@@ -597,7 +597,8 @@ mod tests {
     fn test_default_config_matches_spec() {
         let config: Bm3dConfig<f32> = Bm3dConfig::default();
 
-        assert!(approx_eq(config.sigma_random, 0.0, 1e-6));
+        assert_eq!(RingRemovalMode::default(), RingRemovalMode::Streak);
+        assert!(approx_eq(config.sigma_random, 0.1, 1e-6));
         assert_eq!(config.patch_size, 8);
         assert_eq!(config.step_size, 4);
         assert_eq!(config.search_window, 24);

--- a/src/rust_core/crates/bm3d_gui_egui/Cargo.toml
+++ b/src/rust_core/crates/bm3d_gui_egui/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/ornlneutronimaging/bm3dornl"
 [[bin]]
 name = "bm3dornl-gui"
 path = "src/main.rs"
-test = false  # GUI binary requires HDF5 runtime; tested manually
 
 # macOS app bundle configuration for cargo-bundle
 # Note: version is inherited from [package].version (which uses workspace inheritance)

--- a/src/rust_core/crates/bm3d_gui_egui/src/main.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/main.rs
@@ -320,15 +320,35 @@ impl App {
     fn handle_save_request(&mut self, request: &ui::SaveRequest) {
         use ui::save_dialog::SaveState;
 
+        enum SaveData<'a> {
+            Borrowed(&'a ndarray::Array3<f32>),
+            Owned(ndarray::Array3<f32>),
+        }
+
+        impl<'a> SaveData<'a> {
+            fn as_array(&self) -> &ndarray::Array3<f32> {
+                match self {
+                    SaveData::Borrowed(data) => data,
+                    SaveData::Owned(data) => data,
+                }
+            }
+        }
+
         let data = match request.data_type {
-            SaveDataType::Original => self.volume.as_ref().map(|v| v.raw_data().to_owned()),
+            SaveDataType::Original => self
+                .volume
+                .as_ref()
+                .map(|v| SaveData::Borrowed(v.raw_data())),
             SaveDataType::Processed => self
                 .processed_volume
                 .as_ref()
-                .map(|v| v.raw_data().to_owned()),
+                .map(|v| SaveData::Borrowed(v.raw_data())),
             SaveDataType::Difference => {
                 if let (Some(orig), Some(proc)) = (&self.volume, &self.processed_volume) {
-                    Some(compute_difference(orig.raw_data(), proc.raw_data()))
+                    Some(SaveData::Owned(compute_difference(
+                        orig.raw_data(),
+                        proc.raw_data(),
+                    )))
                 } else {
                     None
                 }
@@ -341,7 +361,7 @@ impl App {
                 message: "Saving...".to_string(),
             };
 
-            match save_volume(&data, request) {
+            match save_volume(data.as_array(), request) {
                 Ok(()) => {
                     self.save_dialog.state = SaveState::Completed {
                         path: request.path.clone(),

--- a/src/rust_core/crates/bm3d_gui_egui/src/ui/parameters.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/ui/parameters.rs
@@ -35,22 +35,21 @@ pub struct Bm3dParameters {
 
 impl Default for Bm3dParameters {
     fn default() -> Self {
-        // GUI defaults optimized for neutron sinogram data:
-        // - MultiscaleStreak as default mode for best quality
-        // - sigma_random: 0.005 (vs Rust default 0.1) - typical noise level for neutron imaging
-        // - max_matches: 32 (vs Rust default 16) - better quality for interactive use
+        let bm3d_default = Bm3dConfig::<f32>::default();
+        let multiscale_default = MultiscaleConfig::<f32>::default();
+
         Self {
-            mode: RingRemovalMode::MultiscaleStreak,
-            sigma_random: 0.005,
-            auto_sigma: true, // Default to auto
-            patch_size: 8,
-            search_window: 24,
-            max_matches: 32,
+            mode: RingRemovalMode::default(),
+            sigma_random: bm3d_default.sigma_random,
+            auto_sigma: bm3d_default.sigma_random <= 1e-6,
+            patch_size: bm3d_default.patch_size,
+            search_window: bm3d_default.search_window,
+            max_matches: bm3d_default.max_matches,
             use_hadamard_fast_mode: false,
             processing_axis: 1, // Default: Y axis (middle dimension)
-            fft_alpha: 1.0,
-            notch_width: 2.0,
-            num_scales: 0, // 0 = auto
+            fft_alpha: bm3d_default.fft_alpha,
+            notch_width: bm3d_default.notch_width,
+            num_scales: multiscale_default.num_scales.unwrap_or(0),
             show_advanced: false,
         }
     }
@@ -141,8 +140,8 @@ impl Bm3dParameters {
 
         ui.horizontal(|ui| {
             ui.label("Method:").on_hover_text(
-                "Multiscale Streak: Best quality for wide ring artifacts (default)\n\
-                 Streak: Single-scale BM3D for narrow streaks\n\
+                "Streak: Default single-scale BM3D for ring artifacts\n\
+                 Multiscale Streak: Best quality for wide ring artifacts\n\
                  Generic: Standard denoising for white noise\n\
                  Fourier-SVD: Fast FFT-guided SVD for subtle artifacts",
             );
@@ -458,9 +457,10 @@ impl Bm3dParameters {
                     .on_hover_text("Reset advanced parameters to their default values")
                     .clicked()
                 {
-                    self.patch_size = 8;
-                    self.search_window = 24;
-                    self.max_matches = 32;
+                    let bm3d_default = Bm3dConfig::<f32>::default();
+                    self.patch_size = bm3d_default.patch_size;
+                    self.search_window = bm3d_default.search_window;
+                    self.max_matches = bm3d_default.max_matches;
                     self.use_hadamard_fast_mode = false;
                     self.processing_axis = 1;
                     changed = true;

--- a/src/rust_core/crates/bm3d_gui_egui/src/ui/parameters.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/ui/parameters.rs
@@ -41,7 +41,7 @@ impl Default for Bm3dParameters {
         Self {
             mode: RingRemovalMode::default(),
             sigma_random: bm3d_default.sigma_random,
-            auto_sigma: bm3d_default.sigma_random <= 1e-6,
+            auto_sigma: true,
             patch_size: bm3d_default.patch_size,
             search_window: bm3d_default.search_window,
             max_matches: bm3d_default.max_matches,

--- a/src/rust_core/crates/bm3d_gui_egui/src/ui/save_dialog.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/ui/save_dialog.rs
@@ -2,6 +2,10 @@ use eframe::egui;
 use ndarray::Array3;
 use std::path::PathBuf;
 
+const TIFF_GRAY32_FLOAT_BYTES_PER_PIXEL: u64 = std::mem::size_of::<f32>() as u64;
+const CLASSIC_TIFF_SAFETY_MARGIN_BYTES: u64 = 64 * 1024 * 1024;
+const CLASSIC_TIFF_MAX_SAFE_BYTES: u64 = u32::MAX as u64 - CLASSIC_TIFF_SAFETY_MARGIN_BYTES;
+
 /// What data to save
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SaveDataType {
@@ -179,7 +183,7 @@ impl SaveDialog {
                                 .selected_text(self.format.name())
                                 .show_ui(ui, |ui| {
                                     ui.selectable_value(&mut self.format, SaveFormat::Tiff, "TIFF Stack")
-                                        .on_hover_text("Multi-page TIFF with 32-bit float values");
+                                        .on_hover_text("Multi-page TIFF with 32-bit float values; large stacks are saved as BigTIFF automatically");
                                     ui.selectable_value(&mut self.format, SaveFormat::Hdf5, "HDF5")
                                         .on_hover_text("HDF5 file with single dataset");
                                 });
@@ -256,9 +260,35 @@ pub fn save_volume(data: &Array3<f32>, request: &SaveRequest) -> Result<(), Stri
 }
 
 fn save_as_tiff(data: &Array3<f32>, path: &PathBuf) -> Result<(), String> {
+    if should_use_bigtiff(data.dim()) {
+        save_as_bigtiff(data, path)
+    } else {
+        save_as_classic_tiff(data, path)
+    }
+}
+
+fn estimated_tiff_payload_bytes((num_slices, height, width): (usize, usize, usize)) -> Option<u64> {
+    let num_slices = u64::try_from(num_slices).ok()?;
+    let height = u64::try_from(height).ok()?;
+    let width = u64::try_from(width).ok()?;
+
+    num_slices
+        .checked_mul(height)?
+        .checked_mul(width)?
+        .checked_mul(TIFF_GRAY32_FLOAT_BYTES_PER_PIXEL)
+}
+
+fn should_use_bigtiff(dim: (usize, usize, usize)) -> bool {
+    match estimated_tiff_payload_bytes(dim) {
+        Some(bytes) => bytes > CLASSIC_TIFF_MAX_SAFE_BYTES,
+        None => true,
+    }
+}
+
+fn save_as_classic_tiff(data: &Array3<f32>, path: &PathBuf) -> Result<(), String> {
     use std::fs::File;
     use std::io::BufWriter;
-    use tiff::encoder::{TiffEncoder, colortype::Gray32Float};
+    use tiff::encoder::TiffEncoder;
 
     let file = File::create(path).map_err(|e| format!("Failed to create file: {}", e))?;
     let writer = BufWriter::new(file);
@@ -266,17 +296,47 @@ fn save_as_tiff(data: &Array3<f32>, path: &PathBuf) -> Result<(), String> {
     let mut encoder =
         TiffEncoder::new(writer).map_err(|e| format!("Failed to create TIFF encoder: {}", e))?;
 
+    write_tiff_pages(data, &mut encoder)
+}
+
+fn save_as_bigtiff(data: &Array3<f32>, path: &PathBuf) -> Result<(), String> {
+    use std::fs::File;
+    use std::io::BufWriter;
+    use tiff::encoder::TiffEncoder;
+
+    let file = File::create(path).map_err(|e| format!("Failed to create file: {}", e))?;
+    let writer = BufWriter::new(file);
+
+    let mut encoder = TiffEncoder::new_big(writer)
+        .map_err(|e| format!("Failed to create BigTIFF encoder: {}", e))?;
+
+    write_tiff_pages(data, &mut encoder)
+}
+
+fn write_tiff_pages<W, K>(
+    data: &Array3<f32>,
+    encoder: &mut tiff::encoder::TiffEncoder<W, K>,
+) -> Result<(), String>
+where
+    W: std::io::Write + std::io::Seek,
+    K: tiff::encoder::TiffKind,
+{
+    use std::borrow::Cow;
+    use tiff::encoder::colortype::Gray32Float;
+
     let (num_slices, height, width) = data.dim();
+    let width = u32::try_from(width).map_err(|_| "TIFF width exceeds u32 limit".to_string())?;
+    let height = u32::try_from(height).map_err(|_| "TIFF height exceeds u32 limit".to_string())?;
 
     for slice_idx in 0..num_slices {
-        let slice_data: Vec<f32> = data
-            .slice(ndarray::s![slice_idx, .., ..])
-            .iter()
-            .copied()
-            .collect();
+        let slice = data.slice(ndarray::s![slice_idx, .., ..]);
+        let slice_data: Cow<'_, [f32]> = match slice.as_slice_memory_order() {
+            Some(values) => Cow::Borrowed(values),
+            None => Cow::Owned(slice.iter().copied().collect()),
+        };
 
         encoder
-            .write_image::<Gray32Float>(width as u32, height as u32, &slice_data)
+            .write_image::<Gray32Float>(width, height, &slice_data)
             .map_err(|e| format!("Failed to write TIFF page {}: {}", slice_idx, e))?;
     }
 

--- a/src/rust_core/crates/bm3d_gui_egui/src/ui/save_dialog.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/ui/save_dialog.rs
@@ -384,6 +384,14 @@ mod tests {
     use ndarray::Array3;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    struct TempFileCleanup(std::path::PathBuf);
+
+    impl Drop for TempFileCleanup {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
     #[test]
     fn estimated_tiff_payload_bytes_uses_checked_arithmetic() {
         assert_eq!(estimated_tiff_payload_bytes((2, 3, 4)), Some(96));
@@ -423,10 +431,10 @@ mod tests {
             std::process::id(),
             unique_id
         ));
+        let _cleanup = TempFileCleanup(path.clone());
 
         save_as_bigtiff(&data, &path).unwrap();
         let loaded = load_tiff_stack(&path).unwrap();
-        let _ = std::fs::remove_file(&path);
 
         assert_eq!(loaded.raw_data().shape(), data.shape());
         assert_eq!(loaded.raw_data(), &data);

--- a/src/rust_core/crates/bm3d_gui_egui/src/ui/save_dialog.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/ui/save_dialog.rs
@@ -376,3 +376,59 @@ fn save_as_hdf5(data: &Array3<f32>, path: &PathBuf, dataset_path: &str) -> Resul
 pub fn compute_difference(original: &Array3<f32>, processed: &Array3<f32>) -> Array3<f32> {
     original - processed
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::load_tiff_stack;
+    use ndarray::Array3;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn estimated_tiff_payload_bytes_uses_checked_arithmetic() {
+        assert_eq!(estimated_tiff_payload_bytes((2, 3, 4)), Some(96));
+        assert_eq!(
+            estimated_tiff_payload_bytes((usize::MAX, usize::MAX, usize::MAX)),
+            None
+        );
+    }
+
+    #[test]
+    fn should_use_bigtiff_switches_at_classic_tiff_safety_limit() {
+        let safe_pixels =
+            (CLASSIC_TIFF_MAX_SAFE_BYTES / TIFF_GRAY32_FLOAT_BYTES_PER_PIXEL) as usize;
+        let too_many_pixels = safe_pixels + 1;
+
+        assert!(!should_use_bigtiff((1, 1, safe_pixels)));
+        assert!(should_use_bigtiff((1, 1, too_many_pixels)));
+        assert!(should_use_bigtiff((usize::MAX, usize::MAX, usize::MAX)));
+    }
+
+    #[test]
+    fn tiny_bigtiff_round_trips_through_stack_loader() {
+        let data = Array3::from_shape_vec(
+            (2, 2, 3),
+            vec![
+                1.0, 2.0, 3.0, 4.5, 5.5, 6.5, 7.0, 8.0, 9.0, 10.5, 11.5, 12.5,
+            ],
+        )
+        .unwrap();
+        let mut path = std::env::temp_dir();
+        let unique_id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!(
+            "bm3dornl-bigtiff-test-{}-{}.tiff",
+            std::process::id(),
+            unique_id
+        ));
+
+        save_as_bigtiff(&data, &path).unwrap();
+        let loaded = load_tiff_stack(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(loaded.raw_data().shape(), data.shape());
+        assert_eq!(loaded.raw_data(), &data);
+    }
+}

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,31 @@
+"""Guard tests for public BM3D default values."""
+
+import inspect
+
+from bm3dornl.bm3d import bm3d_ring_artifact_removal
+
+
+def test_bm3d_ring_artifact_removal_defaults_are_documented_defaults():
+    signature = inspect.signature(bm3d_ring_artifact_removal)
+    defaults = {
+        name: parameter.default
+        for name, parameter in signature.parameters.items()
+        if parameter.default is not inspect.Parameter.empty
+    }
+
+    assert defaults["mode"] == "streak"
+    assert defaults["sigma_random"] == 0.1
+    assert defaults["patch_size"] == 8
+    assert defaults["step_size"] == 4
+    assert defaults["search_window"] == 24
+    assert defaults["max_matches"] == 16
+    assert defaults["threshold"] == 2.7
+    assert defaults["streak_sigma_smooth"] == 3.0
+    assert defaults["streak_iterations"] == 2
+    assert defaults["sigma_map_smoothing"] == 20.0
+    assert defaults["streak_sigma_scale"] == 1.1
+    assert defaults["psd_width"] == 0.6
+    assert defaults["multiscale"] is False
+    assert defaults["num_scales"] is None
+    assert defaults["filter_strength"] == 1.0
+    assert defaults["debin_iterations"] == 30

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -2,6 +2,10 @@
 
 import inspect
 
+import numpy as np
+
+import bm3dornl.bm3d as bm3d_module
+
 from bm3dornl.bm3d import bm3d_ring_artifact_removal
 
 
@@ -19,7 +23,7 @@ def test_bm3d_ring_artifact_removal_defaults_are_documented_defaults():
     assert defaults["step_size"] == 4
     assert defaults["search_window"] == 24
     assert defaults["max_matches"] == 16
-    assert defaults["threshold"] == 2.7
+    assert defaults["threshold"] is None
     assert defaults["streak_sigma_smooth"] == 3.0
     assert defaults["streak_iterations"] == 2
     assert defaults["sigma_map_smoothing"] == 20.0
@@ -29,3 +33,110 @@ def test_bm3d_ring_artifact_removal_defaults_are_documented_defaults():
     assert defaults["num_scales"] is None
     assert defaults["filter_strength"] == 1.0
     assert defaults["debin_iterations"] == 30
+
+
+def test_single_scale_threshold_default_delegates_to_rust_binding(monkeypatch):
+    calls = {}
+
+    def fake_single_scale(sinogram, mode, **kwargs):
+        calls["threshold"] = kwargs["threshold"]
+        return sinogram.copy()
+
+    monkeypatch.setattr(
+        bm3d_module.bm3d_rust,
+        "bm3d_ring_artifact_removal_2d",
+        fake_single_scale,
+    )
+
+    sinogram = np.zeros((8, 8), dtype=np.float32)
+    bm3d_ring_artifact_removal(sinogram)
+
+    assert calls["threshold"] is None
+
+
+def test_multiscale_threshold_default_delegates_to_multiscale_binding(monkeypatch):
+    calls = {}
+
+    def fake_multiscale(sinogram, **kwargs):
+        calls["threshold"] = kwargs["threshold"]
+        return sinogram.copy()
+
+    monkeypatch.setattr(
+        bm3d_module.bm3d_rust,
+        "multiscale_bm3d_streak_removal_2d",
+        fake_multiscale,
+    )
+
+    sinogram = np.zeros((8, 8), dtype=np.float32)
+    bm3d_ring_artifact_removal(sinogram, multiscale=True)
+
+    assert calls["threshold"] is None
+
+
+def test_stack_single_scale_threshold_default_resolves_to_single_scale_default(monkeypatch):
+    calls = {}
+
+    def fake_hard_thresholding_stack(
+        input_noisy,
+        input_pilot,
+        sigma_psd,
+        sigma_map,
+        sigma_random,
+        threshold,
+        patch_size,
+        step_size,
+        search_window,
+        max_matches,
+    ):
+        calls["threshold"] = threshold
+        return input_noisy.copy()
+
+    def fake_wiener_filtering_stack(
+        input_noisy,
+        input_pilot,
+        sigma_psd,
+        sigma_map,
+        sigma_random,
+        patch_size,
+        step_size,
+        search_window,
+        max_matches,
+        progress_callback=None,
+    ):
+        return input_noisy.copy()
+
+    monkeypatch.setattr(
+        bm3d_module.bm3d_rust,
+        "bm3d_hard_thresholding_stack",
+        fake_hard_thresholding_stack,
+    )
+    monkeypatch.setattr(
+        bm3d_module.bm3d_rust,
+        "bm3d_wiener_filtering_stack",
+        fake_wiener_filtering_stack,
+    )
+
+    stack = np.zeros((2, 8, 8), dtype=np.float32)
+    sigma_map = np.zeros_like(stack)
+    bm3d_ring_artifact_removal(stack, mode="generic", sigma_map=sigma_map)
+
+    assert calls["threshold"] == bm3d_module.DEFAULT_SINGLE_SCALE_THRESHOLD
+
+
+def test_stack_multiscale_threshold_default_delegates_to_multiscale_binding(monkeypatch):
+    calls = []
+
+    def fake_multiscale(sinogram, **kwargs):
+        calls.append(kwargs["threshold"])
+        return sinogram.copy()
+
+    monkeypatch.setattr(
+        bm3d_module.bm3d_rust,
+        "multiscale_bm3d_streak_removal_2d",
+        fake_multiscale,
+    )
+
+    stack = np.zeros((2, 8, 8), dtype=np.float32)
+    bm3d_ring_artifact_removal(stack, multiscale=True)
+
+    assert calls == [None, None]


### PR DESCRIPTION
## Summary
- Auto-use BigTIFF for GUI TIFF stack exports that exceed classic TIFF size limits.
- Avoid cloning full Original/Processed volumes before saving from the GUI.
- Sync BM3D defaults across Rust core, Python API, GUI, README, and docs.
- Add a Python guard test for public API defaults.

## Root Cause
Large processed GUI volumes were written as classic multi-page TIFF files, which use 32-bit offsets and fail once output crosses the classic TIFF size boundary. Defaults also drifted because Python, Rust, GUI, and documentation each maintained their own values.

## Validation
- cargo test -p bm3d_core
- cargo check -p bm3d_gui_egui
- cargo clippy -p bm3d_gui_egui --all-targets -- -D warnings
- cargo clippy -p bm3d_core --all-targets -- -D warnings
- cargo fmt --all --check
- python3 -m py_compile src/bm3dornl/bm3d.py tests/test_defaults.py
- pixi run pytest tests/test_defaults.py
- git diff --check

Closes #113
Closes #114