### PR TITLE
security: pin third-party GitHub Actions to commit SHAs + least-privilege permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
     tags: ['v*']
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     name: Linux x86_64
@@ -15,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: x86_64
           manylinux: auto
@@ -34,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: aarch64-apple-darwin
           args: --release --out dist -i python3.12 python3.13 python3.14
@@ -52,7 +55,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           args: --out dist

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           working-directory: src/rust_core/crates/bm3d_gui_egui
           target: x86_64
@@ -47,7 +47,7 @@ jobs:
         run: brew install cmake
 
       - name: Build wheel with maturin
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           working-directory: src/rust_core/crates/bm3d_gui_egui
           target: aarch64-apple-darwin
@@ -67,7 +67,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Install CMake and cargo-bundle
         run: |
@@ -116,7 +118,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/
 
@@ -146,7 +148,7 @@ jobs:
         run: ls -la dist/
 
       - name: Upload assets to existing release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: dist/*
           # Don't set name/body - just upload files to existing release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/
 
@@ -45,7 +45,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Publish bm3d_core to crates.io
         working-directory: src/rust_core
@@ -67,7 +69,7 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   rust-test:
     name: Rust Tests
@@ -18,10 +21,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src/rust_core
 
@@ -45,12 +50,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src/rust_core
 
@@ -70,7 +76,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.62.2
           run-install: false


### PR DESCRIPTION
## What

Supply-chain hardening of the GitHub Actions workflows in this repo, from the 2026-06-22 workspace GitHub Actions security audit:

- **SHA-pin all third-party actions** to full 40-char commit SHAs, retaining a trailing `# version` comment so the human-readable version is still visible.
- **Conservative least-privilege permissions**: added a top-level `permissions:` / `contents: read` block to pure-CI workflows that had no existing top-level permissions block and contained no privilege-requiring strings.

First-party `actions/*` and `github/*` actions, and the local reusable workflow `./.github/workflows/build.yml`, are intentionally left tag-pinned / unchanged.

## Why

Group convention is to pin third-party GitHub Actions to commit SHAs to prevent tag-mutation / supply-chain attacks, and to grant workflows the minimum token scope they need. This PR is the bm3dornl portion of the 2026-06-22 audit.

## Pins applied

- `prefix-dev/setup-pixi@v0.9.6` -> `@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6`
- `pypa/gh-action-pypi-publish@release/v1` -> `@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0`
- `Swatinem/rust-cache@v2` -> `@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2`
- `PyO3/maturin-action@v1` -> `@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1`
- `softprops/action-gh-release@v3` -> `@718ea10b132b3b2eba29c1007bb80653f286566b # v3`
- `dtolnay/rust-toolchain@stable` -> `@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable`

Per-file:
- **build.yml** — 3x maturin-action; added `permissions: contents: read`.
- **gui.yml** — 2x maturin-action, 1x dtolnay/rust-toolchain, gh-action-pypi-publish, action-gh-release; existing top-level permissions block left untouched.
- **release.yml** — gh-action-pypi-publish, 1x dtolnay/rust-toolchain, action-gh-release; existing top-level permissions block left untouched.
- **test.yml** — setup-pixi, 2x Swatinem/rust-cache, 2x dtolnay/rust-toolchain; added `permissions: contents: read`.

16 third-party action pins total.

## Action-specific notes

- **dtolnay/rust-toolchain**: this action derives the Rust channel from its git ref, so a bare SHA pin would break channel selection. Each of the 4 uses (gui.yml, release.yml, 2x test.yml) now carries an explicit `toolchain: stable` input so behavior is preserved.
- `taiki-e/install-action@cargo-llvm-cov` is not present in this repo, so that note does not apply.

## Validation

All four changed workflow files parse as valid YAML, and a grep confirms zero unpinned third-party actions remain. No behavior change intended; CI on this PR validates.

🤖 Assisted with Claude Code
