### PR TITLE
fix(gui): type float literals as f32 for float-literal-f32-fallback lint (fixes next CI)

### DIFF
--- a/src/rust_core/crates/bm3d_gui_egui/src/ui/compare_view.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/ui/compare_view.rs
@@ -550,7 +550,7 @@ impl CompareView {
         painter.rect_stroke(
             response.rect,
             0.0,
-            egui::Stroke::new(1.0, egui::Color32::GRAY),
+            egui::Stroke::new(1.0_f32, egui::Color32::GRAY),
         );
 
         (response, computed_image_rect, painter)
@@ -586,7 +586,7 @@ impl CompareView {
             }
 
             // Border
-            painter.rect_stroke(rect, 0.0, egui::Stroke::new(1.0, egui::Color32::GRAY));
+            painter.rect_stroke(rect, 0.0, egui::Stroke::new(1.0_f32, egui::Color32::GRAY));
 
             // Labels row
             ui.horizontal(|ui| {
@@ -622,7 +622,7 @@ impl CompareView {
             }
 
             // Border
-            painter.rect_stroke(rect, 0.0, egui::Stroke::new(1.0, egui::Color32::GRAY));
+            painter.rect_stroke(rect, 0.0, egui::Stroke::new(1.0_f32, egui::Color32::GRAY));
 
             // Labels row: -max | 0 | +max
             ui.horizontal(|ui| {
@@ -902,9 +902,9 @@ impl CompareView {
                 egui::Color32::from_rgb(255, 255, 0) // Yellow when finalized
             };
             let stroke_width = if self.cursor_in_roi || self.roi_state.moving {
-                3.0
+                3.0_f32
             } else {
-                2.0
+                2.0_f32
             };
             painter.rect_stroke(
                 screen_rect,

--- a/src/rust_core/crates/bm3d_gui_egui/src/ui/slice_view.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/ui/slice_view.rs
@@ -496,7 +496,11 @@ impl SliceViewer {
             self.draw_roi_overlay(&clipped_painter, image_rect, img_width, img_height);
 
             // Draw border around clip area
-            painter.rect_stroke(clip_rect, 0.0, egui::Stroke::new(1.0, egui::Color32::GRAY));
+            painter.rect_stroke(
+                clip_rect,
+                0.0,
+                egui::Stroke::new(1.0_f32, egui::Color32::GRAY),
+            );
         }
 
         // Cursor status bar
@@ -635,7 +639,7 @@ impl SliceViewer {
             }
 
             // Border
-            painter.rect_stroke(rect, 0.0, egui::Stroke::new(1.0, egui::Color32::GRAY));
+            painter.rect_stroke(rect, 0.0, egui::Stroke::new(1.0_f32, egui::Color32::GRAY));
 
             // Labels row
             ui.horizontal(|ui| {
@@ -852,9 +856,9 @@ impl SliceViewer {
                 egui::Color32::from_rgb(255, 255, 0) // Yellow when finalized
             };
             let stroke_width = if self.cursor_in_roi || self.roi_state.moving {
-                3.0
+                3.0_f32
             } else {
-                2.0
+                2.0_f32
             };
             painter.rect_stroke(
                 screen_rect,


### PR DESCRIPTION
## Summary

Fixes the failing **Rust Lint** job on `next` (CI `Test` workflow). Root cause is a Rust toolchain update, not a code change on our side.

## Root cause

CI installs `dtolnay/rust-toolchain@stable` (unpinned) and runs `cargo clippy --workspace --all-targets -- -D warnings`. A stable Rust released after ~2026-07-07 promotes **`float-literal-f32-fallback`** ([rust-lang/rust#154024](https://github.com/rust-lang/rust/issues/154024)) — a warn-by-default *future-incompatibility* lint — for ambiguous float literals that resolve to `f32` via fallback (e.g. `egui::Stroke::new(1.0, ..)`, whose width arg is `impl Into<f32>`). Under `-D warnings`, the 9 occurrences in the GUI crate became hard errors:
- `crates/bm3d_gui_egui/src/ui/compare_view.rs` (5)
- `crates/bm3d_gui_egui/src/ui/slice_view.rs` (4)

The `chore: correct LICENSE …` commit that surfaced this only *triggered* a fresh CI run that picked up the new toolchain — it did not cause the failure (that commit touched only `LICENSE`).

## Fix

Suffix the 9 literals `_f32` — the exact fix the compiler recommends. It's forward-compatible (the lint becomes a hard error in a future Rust release) and behavior-neutral (the values were already `f32`). `slice_view.rs:499` reflowed across lines because `_f32` pushed it past rustfmt's 100-col limit.

## Verification

- Local `pixi run lint` (fmt + clippy) and GUI-crate build pass. Note: my local toolchain is `rustc 1.96.1`, which *predates* the lint, so it cannot exhibit it locally — **this PR's CI run (same unpinned `@stable`) is the authoritative check** that the Rust Lint job is now green.

## Optional follow-up (separate)

The unpinned `@stable` means a future Rust release can spontaneously break the lint gate again, as it did here. Options: pin the toolchain via a `rust-toolchain.toml`, or keep floating `@stable` and fix new lints as they surface. Can open a separate PR if you want pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
