### PR TITLE
style(gui): fix rustfmt + clippy failures from CLI file-loading feature

### DIFF
--- a/src/rust_core/crates/bm3d_gui_egui/src/data/loader.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/data/loader.rs
@@ -165,8 +165,7 @@ fn load_hdf5_dataset_with_progress(
 
     let mut data = Array3::<f32>::zeros((n, h, w));
     for i in 0..n {
-        let slice: Result<ndarray::Array2<f32>, _> =
-            dataset.read_slice(ndarray::s![i, .., ..]);
+        let slice: Result<ndarray::Array2<f32>, _> = dataset.read_slice(ndarray::s![i, .., ..]);
         match slice {
             Ok(slice) => data.slice_mut(ndarray::s![i, .., ..]).assign(&slice),
             // Some dtypes cannot be read as f32 slices — fall back to the
@@ -245,12 +244,9 @@ impl LoadingJob {
         let thread_total = Arc::clone(&total);
         std::thread::spawn(move || {
             let result = match source {
-                LoadSource::Hdf5 { path, dataset } => load_hdf5_dataset_with_progress(
-                    &path,
-                    &dataset,
-                    &thread_done,
-                    &thread_total,
-                ),
+                LoadSource::Hdf5 { path, dataset } => {
+                    load_hdf5_dataset_with_progress(&path, &dataset, &thread_done, &thread_total)
+                }
                 LoadSource::TiffStack(path) => load_tiff_stack(&path),
                 LoadSource::TiffSequence(folder) => load_tiff_sequence(&folder),
             };

--- a/src/rust_core/crates/bm3d_gui_egui/src/data/mod.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/data/mod.rs
@@ -2,7 +2,7 @@ mod loader;
 mod volume;
 
 pub use loader::{
-    DataLoadError, Hdf5Entry, LoadingJob, build_hdf5_tree, find_3d_datasets,
-    load_hdf5_dataset, load_tiff_sequence, load_tiff_stack,
+    DataLoadError, Hdf5Entry, LoadingJob, build_hdf5_tree, find_3d_datasets, load_hdf5_dataset,
+    load_tiff_sequence, load_tiff_stack,
 };
 pub use volume::{AxisMapping, Volume3D};

--- a/src/rust_core/crates/bm3d_gui_egui/src/main.rs
+++ b/src/rust_core/crates/bm3d_gui_egui/src/main.rs
@@ -106,8 +106,10 @@ fn main() -> eframe::Result<()> {
         "bm3dornl - BM3D Ring Artifact Removal",
         options,
         Box::new(move |_cc| {
-            let mut app = App::default();
-            app.return_path = return_path;
+            let mut app = App {
+                return_path,
+                ..Default::default()
+            };
             if let Some(file) = startup_file {
                 app.open_startup_file(file, startup_dataset);
             }


### PR DESCRIPTION
## Why

The Rust Lint CI job is red on `next` ([run 30106559537](https://github.com/ornlneutronimaging/bm3dornl/actions/runs/30106559537)) after bde9501 (`feat(gui): CLI file loading, load progress bar, called-from-app return`). Two independent lint gates fail:

1. **`cargo fmt --all --check`** — three line-wrapping diffs in `loader.rs` and `mod.rs`.
2. **`cargo clippy -- -D warnings`** — `field_reassign_with_default` on `App` in `main.rs:110` (never reported by CI because the fmt step fails first and short-circuits the job).

## What

Purely cosmetic / lint-satisfying, no behavior change:

- **rustfmt**: collapse the wrapped `read_slice` binding, brace the `load_hdf5_dataset_with_progress` match arm, rewrap the `pub use` re-export list.
- **clippy**: construct `App` with struct-init syntax (`App { return_path, ..Default::default() }`) instead of `App::default()` followed by field reassignment.

## Verification

```
pixi run lint   # exit 0 — cargo fmt --all --check + cargo clippy --workspace --all-targets -- -D warnings
```

GUI crate builds clean (`pixi run cargo build -p bm3d_gui_egui` → Finished).

🤖 Generated with [Claude Code](https://claude.com/claude-code)